### PR TITLE
Octal literals are not allowed in strict mode

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -581,7 +581,7 @@ function Client(server, nick, opt) {
 
             case 'err_erroneusnickname':
                 if (self.opt.showErrors)
-                    util.log('\033[01;31mERROR: ' + util.inspect(message) + '\033[0m');
+                    util.log('\u001b[01;31mERROR: ' + util.inspect(message) + '\u001b[0m');
                 self.emit('error', message);
                 break;
 
@@ -1016,7 +1016,7 @@ Client.prototype._handleCTCP = function(from, to, text, type, message) {
 };
 
 Client.prototype.ctcp = function(to, type, text) {
-    return this[type === 'privmsg' ? 'say' : 'notice'](to, '\1' + text + '\1');
+    return this[type === 'privmsg' ? 'say' : 'notice'](to, '\u0001' + text + '\u0001');
 };
 
 Client.prototype.convertEncoding = function(str) {


### PR DESCRIPTION
Certain ES6 features are only available in strict mode. I have been using them in a project that uses node-irc. `node --use-strict` rejects these two lines with the error message

    SyntaxError: Octal literals are not allowed in strict mode.

Thank you for node-irc. It's nice-n-easy to use.